### PR TITLE
Enabled nodeIntegration in browserwindow webPreferences

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,14 @@ module.exports = class ElectronOnline extends EventEmitter {
 
     const init = () => {
       debug('Creating browser window')
-      this.statusWindow = new BrowserWindow({ width: 0, height: 0, show: false })
+      this.statusWindow = new BrowserWindow({ 
+        width: 0, 
+        height: 0, 
+        show: false, 
+        webPreferences: {
+          nodeIntegration: true
+        }
+      })
       this.statusWindow.loadURL(`file://${__dirname}/index.html`)
 
       ipcMain.on('status-changed', (event, status) => {


### PR DESCRIPTION
Events aren't fired unless this is enabled. I'm unsure which version of electron this changed in, but the package doesn't currently work in the `8.0.3` version of electron without this value set.